### PR TITLE
Fix method_exists call

### DIFF
--- a/SamlStaffAuthenticationBackend.class.php
+++ b/SamlStaffAuthenticationBackend.class.php
@@ -103,8 +103,7 @@ class SamlStaffAuthenticationBackend extends ExternalStaffAuthenticationBackend
             $staff_id = StaffSession::getIdByEmail($_SESSION['saml']['nameId']);
 
             if ($staff_id) {
-                if (method_exists(StaffSession, 'lookup')) {
-                    // Assholes
+                if (method_exists('StaffSession', 'lookup')) {
                     $staff_session = StaffSession::lookup($staff_id);
                 } else {
                     $staff_session = new StaffSession($staff_id);


### PR DESCRIPTION
- `object_or_class` must be *An object instance or a class name.*
- Remove offensive comment